### PR TITLE
A lot of misc changes to extern types

### DIFF
--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -21,13 +21,17 @@ In Rust, we don't have this feature. Instead, a couple of problematic hacks are 
 
 One is, we define the type as an uninhabited type. eg.
 
+```rust
     enum MyFfiType {}
+```
 
 Another is, we define the type with a private field and no methods to construct it.
 
+```rust
     struct MyFfiType {
         _priv: (),
     }
+```
 
 The point of both these constructions is to prevent the user from being able to create or deal directly with instances of the type.
 Neither of these types accurately reflect the reality of the situation.
@@ -47,13 +51,17 @@ Just like unions, this is an unsafe feature necessary for dealing with legacy co
 
 Add a new kind of type declaration, an `extern type`:
 
+```rust
     extern type Foo;
+```
 
 These can also be declared inside an `extern` block:
 
+```rust
     extern {
         type Foo;
     }
+```
 
 These types are FFI-safe. They are also DSTs, meaning that they implement `?Sized`. Being DSTs, they cannot be kept on the stack and can only be accessed through pointers.
 

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -66,7 +66,8 @@ These can also be declared inside an `extern` block:
 These types are FFI-safe. They are also DSTs, meaning that they implement `?Sized`. Being DSTs, they cannot be kept on the stack and can only be accessed through pointers.
 
 In Rust, pointers to DSTs carry metadata about the object being pointed to.
-For strings and slices this is the length of the buffer, for trait objects this is the object's vtable. For extern types the metadata is simply `()`.
+For strings and slices this is the length of the buffer, for trait objects this is the object's vtable.
+For extern types the metadata is simply `()`.
 This means that a pointer to an extern type is identical to a raw pointer.
 It also means that if we store an extern type at the end of a container (such as a struct or tuple) pointers to that container will also be identical to raw pointers (despite the container as a whole being unsized).
 This is useful to support a pattern found in some C APIs where structs are passed around which have arbitrary data appended to the end of them: eg.

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -82,6 +82,10 @@ struct FfiStruct {
 }
 ```
 
+As a DST, `size_of` and `align_of` do not work, but we must also be careful that `size_of_val` and `align_of_val` do not work either, as there is not necessarily a way at run-time to get the size of extern types either.
+For an initial implementation, those methods can just panic, but before this is stabilized there should be some trait bound or similar on them that prevents their use statically.
+The exact mechanism is more the domain of the custom DST RFC, [RFC 1524](https://github.com/rust-lang/rfcs/pull/1524), and so figuring that mechanism out will be delegated to it.
+
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this
 

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -39,6 +39,9 @@ None of this is of course valid.
 
 This RFC instead proposes a way to directly express that a type exists but is unknown to Rust.
 
+Finally, In the 2017 roadmap, [integration with other languages](https://github.com/rust-lang/rfcs/blob/master/text/1774-roadmap-2017.md#integration-with-other-languages), is listed as a priority.
+Just like unions, this is an unsafe feature necessary for dealing with legacy code in a correct and understandable manner.
+
 # Detailed design
 [design]: #detailed-design
 

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -63,7 +63,7 @@ These can also be declared inside an `extern` block:
     }
 ```
 
-These types are FFI-safe. They are also DSTs, meaning that they implement `?Sized`. Being DSTs, they cannot be kept on the stack and can only be accessed through pointers.
+These types are FFI-safe. They are also DSTs, meaning that they do not implement `Sized`. Being DSTs, they cannot be kept on the stack and can only be accessed through pointers.
 
 In Rust, pointers to DSTs carry metadata about the object being pointed to.
 For strings and slices this is the length of the buffer, for trait objects this is the object's vtable.

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -12,40 +12,32 @@ system.
 # Motivation
 [motivation]: #motivation
 
-When interacting with external libraries we often need to be able to handle
-pointers to data that we don't know the size or layout of.
+When interacting with external libraries we often need to be able to handle pointers to data that we don't know the size or layout of.
 
-In C it's possible to declare a type but not define it. These incomplete types
-can only be used behind pointers, a compilation error will result if the
-user tries to use them in such a way that the compiler would need to know their
-layout.
+In C it's possible to declare a type but not define it.
+These incomplete types can only be used behind pointers, a compilation error will result if the user tries to use them in such a way that the compiler would need to know their layout.
 
-In Rust, we don't have this feature. Instead, a couple of problematic hacks are
-used in its place.
+In Rust, we don't have this feature. Instead, a couple of problematic hacks are used in its place.
 
 One is, we define the type as an uninhabited type. eg.
 
     enum MyFfiType {}
 
-Another is, we define the type with a private field and no methods to construct
-it.
+Another is, we define the type with a private field and no methods to construct it.
 
     struct MyFfiType {
         _priv: (),
     }
 
-The point of both these constructions is to prevent the user from being able to
-create or deal directly with instances of
-the type. Niether of these types accurately reflect the reality of the
-situation. The first definition is logically problematic as it defines a type
-which can never exist. This means that references to the type can also -
-logically - never exist and raw pointers to the type are guaranteed to be
-invalid. The second definition says that the type is a ZST, that we can store
-it on the stack and that we can call `ptr::read`, `mem::size_of` etc. on it.
+The point of both these constructions is to prevent the user from being able to create or deal directly with instances of the type.
+Neither of these types accurately reflect the reality of the situation.
+The first definition is logically problematic as it defines a type which can never exist.
+This means that references to the type can also—logically—never exist and raw pointers to the type are guaranteed to be
+invalid.
+The second definition says that the type is a ZST, that we can store it on the stack and that we can call `ptr::read`, `mem::size_of` etc. on it.
 None of this is of course valid.
 
-This RFC instead proposes a way to directly express that a type exists but is
-unknown to Rust.
+This RFC instead proposes a way to directly express that a type exists but is unknown to Rust.
 
 # Detailed design
 [design]: #detailed-design
@@ -60,19 +52,13 @@ These can also be declared inside an `extern` block:
         type Foo;
     }
 
-These types are FFI-safe. They are also DSTs, meaning that they implement
-`?Sized`. Being DSTs, they cannot be kept on the stack and can only be
-accessed through pointers.
+These types are FFI-safe. They are also DSTs, meaning that they implement `?Sized`. Being DSTs, they cannot be kept on the stack and can only be accessed through pointers.
 
-In Rust, pointers to DSTs carry metadata about the object being pointed to. For
-strings and slices this is the length of the buffer, for trait objects this is
-the object's vtable. For extern types the metadata is simply `()`. This means
-that a pointer to an extern type is identical to a raw pointer. It also means
-that if we store an extern type at the end of a container (such as a struct or
-tuple) pointers to that container will also be identical to raw pointers
-(despite the container as a whole being unsized). This is useful to support a
-pattern found in some C APIs where structs are passed around which have
-arbitrary data appended to the end of them: eg.
+In Rust, pointers to DSTs carry metadata about the object being pointed to.
+For strings and slices this is the length of the buffer, for trait objects this is the object's vtable. For extern types the metadata is simply `()`.
+This means that a pointer to an extern type is identical to a raw pointer.
+It also means that if we store an extern type at the end of a container (such as a struct or tuple) pointers to that container will also be identical to raw pointers (despite the container as a whole being unsized).
+This is useful to support a pattern found in some C APIs where structs are passed around which have arbitrary data appended to the end of them: eg.
 
 ```rust
 extern type OpaqueTail;
@@ -88,9 +74,8 @@ struct FfiStruct {
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this
 
-This should be taught in the foreign function interface chapter of the rust
-book in place of where it currently tells people to use uninhabited enums
-(ack!).
+
+This should be taught in the foreign function interface chapter of the rust book in place of where it currently tells people to use uninhabited enums (ack!).
 
 # Drawbacks
 [drawbacks]: #drawbacks
@@ -105,6 +90,5 @@ Not do this.
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-Should we allow generic lifetime and type parameters on extern types? If so,
-how do they effect the type in terms of variance?
-
+Should we allow generic lifetime and type parameters on extern types?
+If so, how do they effect the type in terms of variance?

--- a/text/0000-extern-types.md
+++ b/text/0000-extern-types.md
@@ -74,6 +74,16 @@ struct FfiStruct {
 # How We Teach This
 [how-we-teach-this]: #how-we-teach-this
 
+Really, the question is "how do we teach *without* this".
+As described above, the current tricks for doing this are wrong.
+Furthermore, they are quite advanced touching upon many advanced corners of the language: zero-sized and uninhabited types are phenomena few programmer coming from mainstream languages have considered.
+From reading around other RFCs, issues, and internal threads, one gets a sense of two issues:
+First, even among the group Rust programmers enthusiastic enough to participate in these fora, the semantics of foreign types are not widely understood.
+Send, there is annoyance that none of the current tricks, by nature of them all being flawed in different ways, would become standard.
+
+By contrast, `extern type` does exactly what one wants, with an obvious and guessable syntax, without forcing the user to immediately understand all the nuance about why *these* semantics are indeed the right ones.
+As they see various options fail: moves, stack variables, they can discover these semantics incrementally.
+The benefits are such that this would soon displace the current hacks, making code in the wild more readable through consistent use of a pattern.
 
 This should be taught in the foreign function interface chapter of the rust book in place of where it currently tells people to use uninhabited enums (ack!).
 


### PR DESCRIPTION
The first commit I did reformatted to be one sentance per line (see https://github.com/rust-lang/rfcs/issues/1811). I did this to minimize diffs, but then mostly added code, so below we get the opposite effect in practice. So I'd be happy to undo that part. (Or, ust merge the first commit and then look at the diff.)

Also, feel free to steal from this rather than merge it wholesale, thanks again for writing this RFC!